### PR TITLE
mysql client 문자열 변경

### DIFF
--- a/pyconweb2022/pyconweb2022/settings_prod.py
+++ b/pyconweb2022/pyconweb2022/settings_prod.py
@@ -11,6 +11,9 @@ DATABASES = {
         "PASSWORD": os.getenv("AWS_RDS_PW"),
         "HOST": os.getenv("AWS_RDS_HOST"),
         "PORT": os.getenv("AWS_RDS_PORT"),
+        "OPTIONS": {
+            "charset": "utf8bm4"
+        }
     }
 }
 

--- a/pyconweb2022/pyconweb2022/settings_prod.py
+++ b/pyconweb2022/pyconweb2022/settings_prod.py
@@ -11,9 +11,7 @@ DATABASES = {
         "PASSWORD": os.getenv("AWS_RDS_PW"),
         "HOST": os.getenv("AWS_RDS_HOST"),
         "PORT": os.getenv("AWS_RDS_PORT"),
-        "OPTIONS": {
-            "charset": "utf8bm4"
-        }
+        "OPTIONS": {"charset": "utf8bm4"},
     }
 }
 


### PR DESCRIPTION
## Your checklist for this pull request

> ⚠️ [파이콘 한국 Contributing Guide](./CONTRIBUTING.md)를 꼭 준수해주세요.

- PR의 **compare branch를 main나 dev로 생성하지 않아야** 합니다. :smile:
- PR의 **base branch는 dev으로 지정**해야 합니다.
- Commit message가 적절한지 확인해주세요.

## Description

PR에 관한 설명을 상세히 적어주세요.

<img width="316" alt="image" src="https://user-images.githubusercontent.com/10653376/184146608-c57b0106-8a06-4a35-a8b3-c6e61d2bb711.png">

문자열 관련 오류발생으로 문자셋을 직접 지정합니다.
`uf8bm4`

참고자료
*  [MySQL charset (255) unknown to the client in MySQL and AWS RDS](https://dev.to/aws-builders/mysql-charset-255-unknown-to-the-client-in-mysql-and-aws-rds-36fi)

* [[python] Django에서 유니 코드 문자열을 저장할 때 MySQL “잘못된 문자열 값”오류](http://daplus.net/python-django%EC%97%90%EC%84%9C-%EC%9C%A0%EB%8B%88-%EC%BD%94%EB%93%9C-%EB%AC%B8%EC%9E%90%EC%97%B4%EC%9D%84-%EC%A0%80%EC%9E%A5%ED%95%A0-%EB%95%8C-mysql-%EC%9E%98%EB%AA%BB%EB%90%9C-%EB%AC%B8/)
* 
Thank you ❤️
